### PR TITLE
List security scans by image name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ coverage.txt
 
 # CST binary
 cst
+
+# self-signed certificate dir
+.certs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
-FROM golang:1.10-alpine3.7
+FROM golang:1.10-alpine3.8 AS build
 
 ARG repository="github.com/tsuru/cst"
 
 COPY ./ "${GOPATH}/src/${repository}/"
 
-RUN apk update && \
-    apk upgrade && \
-    apk add --virtual .build-deps git make && \
-    cd "${GOPATH}/src/${repository}" && \
-    CSTBIN="/usr/local/bin/cst" make get-dev-deps build && \
-    rm -rf "${GOPATH}/pkg" "${GOPATH}/src" ${GOPATH}/bin/* && \
-    ln -s /usr/local/bin/cst ${GOPATH}/bin/ && \
-    apk del .build-deps && \
-    rm /var/cache/apk/* && \
-    cd /
+RUN apk add --update make && \
+    CSTBIN=/tmp/cst make -C "${GOPATH}/src/${repository}" build
+
+FROM alpine:3.8
+
+COPY --from=build /tmp/cst /usr/local/bin/cst
 
 USER nobody
+
+EXPOSE 8443
 
 ENTRYPOINT ["cst"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO ?= go
+GOROOT ?= $(shell $(GO) env GOROOT)
 GOPATH ?= $(shell $(GO) env GOPATH)
 GOBIN ?= $(GOPATH)/bin
 
@@ -9,8 +10,10 @@ COVERAGE_FILE ?= coverage.out
 
 CSTBIN ?= cst
 CSTMAIN = main.go
+CST_CERTS_DIR ?= .certs
 
 .PHONY: build get-dev-deps lint test test-with-coverage
+		generate-self-signed-certificate
 
 build:
 	$(GODEP) ensure
@@ -29,3 +32,8 @@ test-with-coverage:
 get-dev-deps:
 	$(GO) get -u golang.org/x/lint/golint
 	$(GO) get -u github.com/golang/dep/cmd/dep
+
+generate-self-signed-certificate:
+	mkdir -p $(CST_CERTS_DIR)
+	$(GO) run $(GOROOT)/src/crypto/tls/generate_cert.go --host localhost --ecdsa-curve P256
+	mv cert.pem key.pem $(CST_CERTS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ CST_CERTS_DIR ?= .certs
 		generate-self-signed-certificate
 
 build:
-	$(GODEP) ensure
 	$(GO) build -o "$(CSTBIN)" $(CSTMAIN)
 
 test: lint test-with-coverage

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,13 @@ GOLINT ?= $(GOBIN)/golint
 COVERAGE_FILE ?= coverage.out
 
 CSTBIN ?= cst
-CSTMAIN = main.go
 CST_CERTS_DIR ?= .certs
 
 .PHONY: build get-dev-deps lint test test-with-coverage
 		generate-self-signed-certificate
 
 build:
-	$(GO) build -o "$(CSTBIN)" $(CSTMAIN)
+	$(GO) build -o "$(CSTBIN)"
 
 test: lint test-with-coverage
 

--- a/api/scan.go
+++ b/api/scan.go
@@ -4,10 +4,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/labstack/echo"
+	"github.com/tsuru/cst/db"
 	schd "github.com/tsuru/cst/scan/scheduler"
 )
 
@@ -24,6 +26,23 @@ type scanRequest struct {
 type tsuruEvent struct {
 	scanRequest
 	EndCustomData string `json:"endcustomdata"`
+}
+
+func showScans(ctx echo.Context) error {
+
+	image, err := url.PathUnescape(ctx.Param("image"))
+
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
+
+	scans, err := db.GetStorage().GetScansByImage(image)
+
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	return ctx.JSON(http.StatusOK, scans)
 }
 
 func createScan(ctx echo.Context) error {

--- a/api/scan_test.go
+++ b/api/scan_test.go
@@ -188,7 +188,7 @@ func TestShowScans(t *testing.T) {
 
 		context := e.NewContext(request, recorder)
 
-		context.SetPath("/v1/container/scan/:image")
+		context.SetPath("/v1/scan/:image")
 		context.SetParamNames("image")
 		context.SetParamValues(url.PathEscape("tsuru/cst:latest"))
 
@@ -209,7 +209,7 @@ func TestShowScans(t *testing.T) {
 
 		context := e.NewContext(request, recorder)
 
-		context.SetPath("/v1/container/scan/:image")
+		context.SetPath("/v1/scan/:image")
 		context.SetParamNames("image")
 		context.SetParamValues("badUrlEncoded%ss")
 
@@ -236,7 +236,7 @@ func TestShowScans(t *testing.T) {
 
 		context := e.NewContext(request, recorder)
 
-		context.SetPath("/v1/container/scan/:image")
+		context.SetPath("/v1/scan/:image")
 		context.SetParamNames("image")
 		context.SetParamValues(url.PathEscape("tsuru/cst:latest"))
 
@@ -271,7 +271,7 @@ func TestShowScans(t *testing.T) {
 
 		context := e.NewContext(request, recorder)
 
-		context.SetPath("/v1/container/scan/:image")
+		context.SetPath("/v1/scan/:image")
 		context.SetParamNames("image")
 		context.SetParamValues(url.PathEscape("tsuru/cst:latest"))
 

--- a/api/server.go
+++ b/api/server.go
@@ -38,6 +38,7 @@ func (ws *SecureWebServer) Start() error {
 
 	v1 := ws.echo.Group("/v1")
 	v1.POST("/container/scan", createScan)
+	v1.GET("/container/scan/:image", showScans)
 
 	address := fmt.Sprintf(":%d", ws.Port)
 

--- a/api/server.go
+++ b/api/server.go
@@ -37,8 +37,8 @@ func (ws *SecureWebServer) Start() error {
 	ws.echo.Use(middleware.Logger())
 
 	v1 := ws.echo.Group("/v1")
-	v1.POST("/container/scan", createScan)
-	v1.GET("/container/scan/:image", showScans)
+	v1.POST("/scan", createScan)
+	v1.GET("/scan/:image", showScans)
 
 	address := fmt.Sprintf(":%d", ws.Port)
 

--- a/db/mock.go
+++ b/db/mock.go
@@ -6,6 +6,7 @@ import "github.com/tsuru/cst/scan"
 type MockStorage struct {
 	MockAppendResultToScanByID  func(string, scan.Result) error
 	MockClose                   func()
+	MockGetScansByImage         func(string) ([]scan.Scan, error)
 	MockHasScheduledScanByImage func(string) bool
 	MockSave                    func(scan.Scan) error
 	MockUpdateScanStatusByID    func(string, scan.Status) error
@@ -27,6 +28,16 @@ func (ms *MockStorage) Close() {
 	if ms.MockClose != nil {
 		ms.MockClose()
 	}
+}
+
+// GetScansByImage is a mock implementation for testing purposes.
+func (ms *MockStorage) GetScansByImage(image string) ([]scan.Scan, error) {
+
+	if ms.MockGetScansByImage != nil {
+		return ms.MockGetScansByImage(image)
+	}
+
+	return []scan.Scan{}, nil
 }
 
 // HasScheduledScanByImage is a mock implementation for testing purposes.

--- a/db/mongodb/mongo.go
+++ b/db/mongodb/mongo.go
@@ -64,6 +64,19 @@ func (mongo *MongoDB) UpdateScanStatusByID(id string, status scan.Status) error 
 	return collection.UpdateId(id, bson.M{"$set": bson.M{"status": status}})
 }
 
+// GetScansByImage returns the list of scans that match a given image name.
+func (mongo *MongoDB) GetScansByImage(image string) ([]scan.Scan, error) {
+
+	collection := mongo.getScanCollection()
+	defer collection.Database.Session.Close()
+
+	var scans []scan.Scan
+
+	err := collection.Find(bson.M{"image": image}).All(&scans)
+
+	return scans, err
+}
+
 func (mongo *MongoDB) getScanCollection() *mgo.Collection {
 
 	session := mongo.session.Copy()

--- a/db/storage.go
+++ b/db/storage.go
@@ -6,6 +6,7 @@ import "github.com/tsuru/cst/scan"
 type Storage interface {
 	AppendResultToScanByID(string, scan.Result) error
 	Close()
+	GetScansByImage(image string) ([]scan.Scan, error)
 	HasScheduledScanByImage(string) bool
 	UpdateScanStatusByID(string, scan.Status) error
 	Save(scan.Scan) error


### PR DESCRIPTION
This PR allows to view the security scans of a given container image. The new route returns a JSON array with all scans so far.  

Below is an example to test the new route.

```
curl https://localhost:8443/v1/container/scan/tsuru%2Fcst%3Alatest
```